### PR TITLE
[Merge ntfs] Do not merge if there are 2 same physical modes

### DIFF
--- a/fixtures/merge-ntfs/physical_modes.txt
+++ b/fixtures/merge-ntfs/physical_modes.txt
@@ -1,4 +1,6 @@
 physical_mode_id,physical_mode_name,co2_emission
+Bus,Bus,
+Metro,Metro,
 Funicular,"Funiculaire",
 Train,"Train",11.9
 Tramway,"Tramway",4

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -451,9 +451,11 @@ impl<T: Id<T>> CollectionWithId<T> {
         }
         Ok(())
     }
+}
 
-    /// Merge a `CollectionWithId` parameter into the current one.
-    /// without duplicating ids.
+impl<T: Id<T>> iter::Extend<T> for CollectionWithId<T> {
+    /// Extend a `CollectionWithId` with the content of an iterator of
+    /// CollectionWithId without duplicated ids.
     ///
     /// # Examples
     ///
@@ -464,14 +466,14 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # impl Id<Obj> for Obj { fn id(&self) -> &str { self.0 } }
     /// let mut c1 = CollectionWithId::new(vec![Obj("foo"), Obj("bar")])?;
     /// let mut c2 = CollectionWithId::new(vec![Obj("foo"), Obj("qux")])?;
-    /// c1.safe_merge(c2);
+    /// c1.extend(c2);
     /// assert_eq!(c1.len(), 3);
     /// # Ok(())
     /// # }
     /// # fn main() { run().unwrap() }
     /// ```
-    pub fn safe_merge(&mut self, other: Self) {
-        for item in other {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for item in iter {
             skip_fail!(self.push(item));
         }
     }

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -451,6 +451,30 @@ impl<T: Id<T>> CollectionWithId<T> {
         }
         Ok(())
     }
+
+    /// Merge a `CollectionWithId` parameter into the current one.
+    /// without duplicating ids.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use navitia_model::collection::*;
+    /// # fn run() -> navitia_model::Result<()> {
+    /// # #[derive(PartialEq, Debug)] struct Obj(&'static str);
+    /// # impl Id<Obj> for Obj { fn id(&self) -> &str { self.0 } }
+    /// let mut c1 = CollectionWithId::new(vec![Obj("foo"), Obj("bar")])?;
+    /// let mut c2 = CollectionWithId::new(vec![Obj("foo"), Obj("qux")])?;
+    /// c1.safe_merge(c2);
+    /// assert_eq!(c1.len(), 3);
+    /// # Ok(())
+    /// # }
+    /// # fn main() { run().unwrap() }
+    /// ```
+    pub fn safe_merge(&mut self, other: Self) {
+        for item in other {
+            skip_fail!(self.push(item));
+        }
+    }
 }
 
 impl<T> CollectionWithId<T> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -82,7 +82,7 @@ impl Collections {
         self.lines.merge(lines)?;
         self.routes.merge(routes)?;
         self.vehicle_journeys.merge(vehicle_journeys)?;
-        self.physical_modes.safe_merge(physical_modes);
+        self.physical_modes.extend(physical_modes);
         self.stop_areas.merge(stop_areas)?;
         self.stop_points.merge(stop_points)?;
         self.feed_infos.extend(feed_infos);

--- a/src/model.rs
+++ b/src/model.rs
@@ -82,7 +82,7 @@ impl Collections {
         self.lines.merge(lines)?;
         self.routes.merge(routes)?;
         self.vehicle_journeys.merge(vehicle_journeys)?;
-        self.physical_modes.merge(physical_modes)?;
+        self.physical_modes.safe_merge(physical_modes);
         self.stop_areas.merge(stop_areas)?;
         self.stop_points.merge(stop_points)?;
         self.feed_infos.extend(feed_infos);


### PR DESCRIPTION
Before merge was crashing if there were 2 identical physical modes

Now

physical_mode_id|physical_mode_name
---|---
Bus|Bus
Metro|Metro
RapidTransit|Rapid Transit

merged with 

physical_mode_id|physical_mode_name
---|---
Bus|Bus
Metro|Metro
Funicular|Funiculaire
Train|Train
Tramway|Tramway

result

physical_mode_id|physical_mode_name
---|---
Bus|Bus
Metro|Metro
RapidTransit|Rapid Transit
Funicular|Funiculaire
Train|Train
Tramway|Tramway



