### PR TITLE
Removed some warnings + minor fixes

### DIFF
--- a/src/bin/gtfs2ntfs.rs
+++ b/src/bin/gtfs2ntfs.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/merge-ntfs.rs
+++ b/src/bin/merge-ntfs.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/merge-stop-areas.rs
+++ b/src/bin/merge-stop-areas.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/netex2ntfs.rs
+++ b/src/bin/netex2ntfs.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/ntfs2gtfs.rs
+++ b/src/bin/ntfs2gtfs.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/ntfs2ntfs.rs
+++ b/src/bin/ntfs2ntfs.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/bin/transfers.rs
+++ b/src/bin/transfers.rs
@@ -18,7 +18,6 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate navitia_model;
-#[macro_use]
 extern crate structopt;
 
 use std::path::PathBuf;

--- a/src/common_format.rs
+++ b/src/common_format.rs
@@ -131,7 +131,7 @@ impl Calendar {
     fn get_valid_dates(&self) -> BTreeSet<Date> {
         let valid_days = self.get_valid_days();
         let duration = self.end_date - self.start_date;
-        (0..duration.num_days() + 1)
+        (0..=duration.num_days())
             .map(|i| self.start_date + chrono::Duration::days(i))
             .filter(|d| valid_days.contains(&d.weekday()))
             .collect()

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -83,7 +83,7 @@ fn ntfs_stop_point_to_gtfs_stop(
         .clone()
         .and_then(|eq_id| equipments.get(&eq_id))
         .map(|eq| eq.wheelchair_boarding)
-        .unwrap_or_else(|| Availability::default());
+        .unwrap_or_else(Availability::default);
     Stop {
         id: sp.id.clone(),
         name: sp.name.clone(),
@@ -110,7 +110,7 @@ fn ntfs_stop_area_to_gtfs_stop(
         .clone()
         .and_then(|eq_id| equipments.get(&eq_id))
         .map(|eq| eq.wheelchair_boarding)
-        .unwrap_or_else(|| Availability::default());
+        .unwrap_or_else(Availability::default);
     Stop {
         id: sa.id.clone(),
         name: sa.name.clone(),
@@ -465,7 +465,7 @@ mod tests {
             name: "sp_name_1".to_string(),
             codes: BTreeSet::default(),
             object_properties: BTreeSet::default(),
-            comment_links: comment_links,
+            comment_links,
             visible: true,
             coord: objects::Coord {
                 lon: 2.073034,
@@ -584,7 +584,7 @@ mod tests {
             name: "sa_name_1".to_string(),
             codes: BTreeSet::default(),
             object_properties: BTreeSet::default(),
-            comment_links: comment_links,
+            comment_links,
             visible: true,
             coord: objects::Coord {
                 lon: 2.073034,

--- a/src/merge_stop_areas.rs
+++ b/src/merge_stop_areas.rs
@@ -148,7 +148,7 @@ fn group_rules_from_file_rules(
     for file_rule in file_rules {
         rules_with_priority
             .entry(file_rule.group)
-            .or_insert(vec![])
+            .or_insert_with(|| vec![])
             .push((file_rule.id.clone(), file_rule.priority));
     }
     let group_rules: HashMap<String, StopAreaGroupRule> = rules_with_priority
@@ -176,7 +176,7 @@ fn group_rules_from_file_rules(
                 },
             ))
         }).collect();
-    group_rules.values().into_iter().cloned().collect()
+    group_rules.values().cloned().collect()
 }
 
 fn read_rules<P: AsRef<path::Path>>(

--- a/src/netex/read.rs
+++ b/src/netex/read.rs
@@ -51,7 +51,7 @@ impl NetexReader {
         file.read_to_string(&mut file_content)?;
         let root: Element = file_content.parse()?;
 
-        self.context.namespace = root.ns().unwrap_or("".to_string());
+        self.context.namespace = root.ns().unwrap_or_else(|| "".to_string());
 
         for frame in root
             .get_child("dataObjects", self.context.namespace.as_str())


### PR DESCRIPTION
- removed `warning: unused `#[macro_use]` import` after upgrading to rustc 1.30.0
- minor fixes
