### PR TITLE
Added apply-rules

### DIFF
--- a/fixtures/apply_rules/complementary_codes_rules.txt
+++ b/fixtures/apply_rules/complementary_codes_rules.txt
@@ -1,0 +1,9 @@
+object,object_id,system_name,system_code
+line,RERA,OSM,Relation:3195542
+line,RERA,OSM,Relation:3224933
+route,B42F,OSM,Relation:3187722
+route,B42B,OSM,Relation:3187723
+stop_point,GDLR,OSM,Node:1681252530
+stop_area,CDG,OSM,Node:1730401509
+stop_area,CDG,OSM,Node:1730401509
+object_not_allowed,NATM,OSM,Node:1730401509

--- a/fixtures/apply_rules/output/object_codes.txt
+++ b/fixtures/apply_rules/output/object_codes.txt
@@ -1,0 +1,7 @@
+object_type,object_id,object_system,object_code
+stop_area,CDG,OSM,Node:1730401509
+stop_point,GDLR,OSM,Node:1681252530
+line,RERA,OSM,Relation:3195542
+line,RERA,OSM,Relation:3224933
+route,B42F,OSM,Relation:3187722
+route,B42B,OSM,Relation:3187723

--- a/fixtures/apply_rules/output/report.json
+++ b/fixtures/apply_rules/output/report.json
@@ -1,0 +1,9 @@
+{
+  "errors": [],
+  "warnings": [
+    {
+      "category": "ComplementaryCodeRulesRead",
+      "message": "Error reading \"./fixtures/apply_rules/complementary_codes_rules.txt\": CSV deserialize error: record 8 (line: 9, byte: 271): unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
+    }
+  ]
+}

--- a/src/apply_rules.rs
+++ b/src/apply_rules.rs
@@ -1,0 +1,135 @@
+// Copyright 2017-2018 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+//! See function apply_rules
+
+use collection::{CollectionWithId, Id};
+use csv;
+use failure::ResultExt;
+use model::Collections;
+use objects::Codes;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use utils::{Report, ReportType};
+use Result;
+
+#[derive(Deserialize, Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+enum Object {
+    Line,
+    Route,
+    StopPoint,
+    StopArea,
+}
+impl Object {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            Object::Line => "line",
+            Object::Route => "route",
+            Object::StopPoint => "stop_point",
+            Object::StopArea => "stop_area",
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Ord, Eq, PartialOrd, PartialEq, Clone)]
+struct ComplementaryCode {
+    object: Object,
+    object_id: String,
+    system_name: String,
+    system_code: String,
+}
+
+fn read_complementary_code_rules_files<P: AsRef<Path>>(
+    rule_files: Vec<P>,
+    report: &mut Report,
+) -> Result<Vec<ComplementaryCode>> {
+    info!("Reading complementary code rules.");
+    let mut codes = BTreeSet::new();
+    for rule_path in rule_files {
+        let path = rule_path.as_ref();
+        let mut rdr = csv::Reader::from_path(&path).with_context(ctx_from_path!(path))?;
+        for c in rdr.deserialize() {
+            let c: ComplementaryCode = match c {
+                Ok(val) => val,
+                Err(e) => {
+                    report.add_warning(
+                        format!("Error reading {:?}: {}", path, e),
+                        ReportType::ComplementaryCodeRulesRead,
+                    );
+                    continue;
+                }
+            };
+            codes.insert(c);
+        }
+    }
+    Ok(codes.into_iter().collect())
+}
+
+fn insert_code<T>(
+    collection: &mut CollectionWithId<T>,
+    code: ComplementaryCode,
+    report: &mut Report,
+) where
+    T: Codes + Id<T>,
+{
+    let idx = match collection.get_idx(&code.object_id) {
+        Some(idx) => idx,
+        None => {
+            report.add_warning(
+                format!(
+                    "Error inserting code: object_codes.txt: object={},  object_id={} not found",
+                    code.object.as_str(),
+                    code.object_id
+                ),
+                ReportType::ComplementaryObjectNotFound,
+            );
+            return;
+        }
+    };
+
+    collection
+        .index_mut(idx)
+        .codes_mut()
+        .insert((code.system_name, code.system_code));
+}
+
+/// Applying rules
+///
+/// `complementary_code_rules_files` Csv files containing codes to add for certain objects
+pub fn apply_rules(
+    collections: &mut Collections,
+    complementary_code_rules_files: Vec<PathBuf>,
+    report_path: PathBuf,
+) -> Result<()> {
+    info!("Applying rules...");
+    let mut report = Report::default();
+    let codes = read_complementary_code_rules_files(complementary_code_rules_files, &mut report)?;
+
+    for code in codes {
+        match code.object {
+            Object::Line => insert_code(&mut collections.lines, code, &mut report),
+            Object::Route => insert_code(&mut collections.routes, code, &mut report),
+            Object::StopPoint => insert_code(&mut collections.stop_points, code, &mut report),
+            Object::StopArea => insert_code(&mut collections.stop_areas, code, &mut report),
+        }
+    }
+
+    let serialized_report = serde_json::to_string_pretty(&report)?;
+    fs::write(report_path, serialized_report)?;
+    Ok(())
+}

--- a/src/bin/apply-rules.rs
+++ b/src/bin/apply-rules.rs
@@ -1,0 +1,83 @@
+// Copyright 2017-2018 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+extern crate env_logger;
+#[macro_use]
+extern crate log;
+extern crate navitia_model;
+extern crate structopt;
+
+use structopt::StructOpt;
+
+use navitia_model::Result;
+use std::path::PathBuf;
+
+use navitia_model::apply_rules;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "apply_rules", about = " Enrich the data of an NTFS.")]
+struct Opt {
+    /// input directory.
+    #[structopt(
+        short = "i",
+        long = "input",
+        parse(from_os_str),
+        default_value = "."
+    )]
+    input: PathBuf,
+
+    /// complementary code rules files.
+    #[structopt(
+        short = "c",
+        long = "complementary-code-rules",
+        parse(from_os_str),
+    )]
+    complementary_code_rules_files: Vec<PathBuf>,
+
+    /// output report file path
+    #[structopt(short = "r", long = "report", parse(from_os_str))]
+    report: PathBuf,
+
+    /// output directory
+    #[structopt(short = "o", long = "output", parse(from_os_str))]
+    output: PathBuf,
+}
+
+fn run() -> Result<()> {
+    info!("Launching apply_rules.");
+    let opt = Opt::from_args();
+    let model = navitia_model::ntfs::read(opt.input)?;
+    let mut collections = model.into_collections();
+    apply_rules::apply_rules(
+        &mut collections,
+        opt.complementary_code_rules_files,
+        opt.report,
+    )?;
+    let model = navitia_model::Model::new(collections)?;
+    navitia_model::ntfs::write(&model, opt.output)?;
+
+    Ok(())
+}
+
+fn main() {
+    env_logger::init();
+    if let Err(err) = run() {
+        for cause in err.iter_chain() {
+            eprintln!("{}", cause);
+        }
+        std::process::exit(1);
+    }
+}

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -84,8 +84,7 @@ fn get_first_comment_name<T: objects::CommentLinks>(
 fn ntfs_codes_to_gtfs_code<T: Codes>(obj: &T) -> Option<String> {
     obj.codes()
         .iter()
-        .filter(|c| c.0 == "gtfs_stop_code")
-        .next()
+        .find(|c| c.0 == "gtfs_stop_code")
         .cloned()
         .map(|c| c.1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ extern crate wkt;
 
 #[macro_use]
 pub(crate) mod utils;
+pub mod apply_rules;
 pub mod collection;
 pub(crate) mod common_format;
 pub mod gtfs;

--- a/src/ntfs/write.rs
+++ b/src/ntfs/write.rs
@@ -289,9 +289,6 @@ pub fn write_codes(path: &path::Path, collections: &Collections) -> Result<()> {
         return Ok(());
     }
 
-    if collections.comments.is_empty() {
-        return Ok(());
-    }
     info!("Writing object_codes.txt");
 
     let path = path.join("object_codes.txt");

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,24 +22,28 @@ use std::path;
 
 use self::tempdir::TempDir;
 
-pub fn compare_output_dir_with_expected(
-    output_dir: &Path,
-    files_to_check: &[String],
-    work_dir_expected: String,
+fn get_file_content<P: AsRef<Path>>(path: P) -> String {
+    let path = path.as_ref();
+    let mut output_file = File::open(path).unwrap_or_else(|_| panic!("file {:?} not found", path));
+    let mut output_contents = String::new();
+    output_file.read_to_string(&mut output_contents).unwrap();
+
+    output_contents
+}
+
+pub fn compare_output_dir_with_expected<P: AsRef<Path>>(
+    output_dir: &P,
+    files_to_check: Vec<&str>,
+    work_dir_expected: &str,
 ) {
+    let output_dir = output_dir.as_ref();
     for filename in files_to_check {
         let output_file_path = output_dir.join(filename);
-        let mut output_file = File::open(output_file_path.clone())
-            .expect(&format!("file {:?} not found", output_file_path));
-        let mut output_contents = String::new();
-        output_file.read_to_string(&mut output_contents).unwrap();
+        let output_contents = get_file_content(output_file_path);
+
         let expected_file_path = format!("{}/{}", work_dir_expected, filename);
-        let mut expected_file = File::open(expected_file_path.clone())
-            .expect(&format!("file {} not found", expected_file_path));
-        let mut expected_contents = String::new();
-        expected_file
-            .read_to_string(&mut expected_contents)
-            .unwrap();
+        let expected_contents = get_file_content(expected_file_path);
+
         assert_eq!(output_contents, expected_contents);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -273,3 +273,31 @@ macro_rules! skip_fail {
         }
     };
 }
+
+#[derive(Debug, Serialize)]
+pub enum ReportType {
+    // apply-rules types
+    ComplementaryCodeRulesRead,
+    ComplementaryObjectNotFound,
+}
+
+#[derive(Debug, Serialize)]
+struct ReportRow {
+    category: ReportType,
+    message: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Report {
+    errors: Vec<ReportRow>,
+    warnings: Vec<ReportRow>,
+}
+
+impl Report {
+    pub fn add_warning(&mut self, warning: String, warning_type: ReportType) {
+        self.warnings.push(ReportRow {
+            category: warning_type,
+            message: warning,
+        });
+    }
+}

--- a/tests/apply_rules.rs
+++ b/tests/apply_rules.rs
@@ -1,0 +1,45 @@
+// Copyright 2017-2018 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+extern crate navitia_model;
+use navitia_model::apply_rules;
+use navitia_model::test_utils::*;
+use std::path::Path;
+
+#[test]
+fn test_apply_complementary_codes() {
+    test_in_tmp_dir(|path| {
+        let input_dir = "fixtures/minimal_ntfs";
+        let rules =
+            vec![Path::new("./fixtures/apply_rules/complementary_codes_rules.txt").to_path_buf()];
+        let report_path = path.join("report.json");
+
+        let model = navitia_model::ntfs::read(input_dir).unwrap();
+        let mut collections = model.into_collections();
+        apply_rules::apply_rules(
+            &mut collections,
+            rules,
+            Path::new(&report_path).to_path_buf(),
+        ).unwrap();
+        let model = navitia_model::Model::new(collections).unwrap();
+        navitia_model::ntfs::write(&model, path).unwrap();
+        compare_output_dir_with_expected(
+            &path,
+            vec!["object_codes.txt", "report.json"],
+            "./fixtures/apply_rules/output",
+        );
+    });
+}

--- a/tests/merge_stop_areas.rs
+++ b/tests/merge_stop_areas.rs
@@ -18,57 +18,42 @@
 extern crate navitia_model;
 
 use navitia_model::model::Model;
-use std::fs::File;
-use std::io::prelude::*;
 use std::path::Path;
 extern crate tempdir;
-use self::tempdir::TempDir;
-
-fn compare_output_dir_with_expected(output_dir: &Path) {
-    for filename in vec![
-        "comment_links.txt",
-        "comments.txt",
-        "geometries.txt",
-        "lines.txt",
-        "object_codes.txt",
-        "object_properties.txt",
-        "stops.txt",
-        "report.json",
-    ] {
-        let output_file_path = output_dir.join(filename);
-        let mut output_file = File::open(output_file_path.clone())
-            .expect(&format!("file {:?} not found", output_file_path));
-        let mut output_contents = String::new();
-        output_file.read_to_string(&mut output_contents).unwrap();
-        let expected_file_path = format!("./fixtures/merge-stop-areas/output/{}", filename);
-        let mut expected_file = File::open(expected_file_path.clone())
-            .expect(&format!("file {} not found", expected_file_path));
-        let mut expected_contents = String::new();
-        expected_file
-            .read_to_string(&mut expected_contents)
-            .unwrap();
-        assert_eq!(output_contents, expected_contents);
-    }
-}
+use navitia_model::test_utils::*;
 
 #[test]
 fn test_merge_stop_areas_multi_steps() {
-    let paths = vec![
-        Path::new("./fixtures/merge-stop-areas/rule1.csv").to_path_buf(),
-        Path::new("./fixtures/merge-stop-areas/rule2.csv").to_path_buf(),
-    ];
-    let objects =
-        navitia_model::ntfs::read(Path::new("./fixtures/merge-stop-areas/ntfs-to-merge")).unwrap();
-    let tmp_dir = TempDir::new("navitia_model_tests").expect("create temp dir");
-    let report_path = tmp_dir.path().join("report.json");
-    let collections = navitia_model::merge_stop_areas::merge_stop_areas(
-        objects.into_collections(),
-        paths,
-        200,
-        Path::new(&report_path).to_path_buf(),
-    ).unwrap();
-    let new_model = Model::new(collections).unwrap();
-    navitia_model::ntfs::write(&new_model, tmp_dir.path()).unwrap();
-    compare_output_dir_with_expected(tmp_dir.path());
-    tmp_dir.close().expect("delete temp dir");
+    test_in_tmp_dir(|path| {
+        let paths = vec![
+            Path::new("./fixtures/merge-stop-areas/rule1.csv").to_path_buf(),
+            Path::new("./fixtures/merge-stop-areas/rule2.csv").to_path_buf(),
+        ];
+        let objects =
+            navitia_model::ntfs::read(Path::new("./fixtures/merge-stop-areas/ntfs-to-merge"))
+                .unwrap();
+        let report_path = path.join("report.json");
+        let collections = navitia_model::merge_stop_areas::merge_stop_areas(
+            objects.into_collections(),
+            paths,
+            200,
+            Path::new(&report_path).to_path_buf(),
+        ).unwrap();
+        let new_model = Model::new(collections).unwrap();
+        navitia_model::ntfs::write(&new_model, path).unwrap();
+        compare_output_dir_with_expected(
+            &path,
+            vec![
+                "comment_links.txt",
+                "comments.txt",
+                "geometries.txt",
+                "lines.txt",
+                "object_codes.txt",
+                "object_properties.txt",
+                "stops.txt",
+                "report.json",
+            ],
+            "./fixtures/merge-stop-areas/output/",
+        );
+    });
 }

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -102,11 +102,7 @@ fn ntfs_stops_output() {
     let ntm = navitia_model::ntfs::read("fixtures/minimal_ntfs/").unwrap();
     test_in_tmp_dir(|output_dir| {
         navitia_model::ntfs::write(&ntm, output_dir).unwrap();
-        compare_output_dir_with_expected(
-            output_dir,
-            &["stops.txt".to_string()],
-            "fixtures/ntfs2ntfs".to_string(),
-        );
+        compare_output_dir_with_expected(&output_dir, vec!["stops.txt"], "fixtures/ntfs2ntfs");
     });
 }
 


### PR DESCRIPTION
Add object codes to line, route, stop_point, stop_area with a configuration csv file

Ex : complementary_codes_rules.txt
```csv
object,object_id,system_name,system_code
line,RERA,OSM,Relation:3195542
line,RERA,OSM,Relation:3224933
route,B42F,OSM,Relation:3187722
route,B42B,OSM,Relation:3187723
stop_point,GDLR,OSM,Node:1681252530
stop_area,CDG,OSM,Node:1730401509
```

`./target/release/apply-rules  -i . -c complementary_codes_rules.txt  -o output -r report.json`

`report.json` will contains 2 warnings
- **ComplementaryCodeRulesRead** if the csv is invalid
- **ComplementaryObjectNotFound** if an object is not found

ex `report.json`
```json
{
  "errors": [],
  "warnings": [
    {
      "category": "ComplementaryCodeRulesRead",
      "message": "Error reading \"complementary_codes_rules2.txt\": CSV deserialize error: record 8 (line: 9, byte: 381): unknown variant `bite`, expected one of `line`, `route`, `stop_point`, `stop_area`"
    },
    {
      "category": "ComplementaryObjectNotFound",
      "message": "Error inserting code: object_codes.txt: object=stop_point,  object_id=ONY:nexistepas not found"
    }
  ]
}
```
