### PR TITLE
make total seconds public to ease use

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -707,7 +707,7 @@ impl Time {
     pub fn seconds(&self) -> u32 {
         self.0 % 60
     }
-    fn total_seconds(&self) -> u32 {
+    pub fn total_seconds(&self) -> u32 {
         self.0
     }
 }


### PR DESCRIPTION
it will make the transiberian handling for https://github.com/etalab/transpo-rt/pull/32

I plan to create a `DateTime` from the `Time` + a `Date` with: 

`date.and_time(chrono::NaiveTime::from_hms(0, 0, 0))
        + chrono::Duration::seconds(time.total_seconds() as i64)`