### PR TITLE
[gtfs2ntfs] remove commercial mode prefix

### DIFF
--- a/fixtures/merge-ntfs/input/commercial_modes.txt
+++ b/fixtures/merge-ntfs/input/commercial_modes.txt
@@ -2,3 +2,4 @@ commercial_mode_id,commercial_mode_name
 rapidtransit,"RER"
 train,"Train"
 tram,"Tramway"
+Bus,"Bus"

--- a/src/bin/merge-ntfs.rs
+++ b/src/bin/merge-ntfs.rs
@@ -72,7 +72,7 @@ fn run() -> Result<()> {
         let mut collections = Collections::default();
         for input_directory in opt.input_directories {
             let to_append_model = navitia_model::ntfs::read(input_directory)?;
-            collections.merge(to_append_model.into_collections())?;
+            collections.try_merge(to_append_model.into_collections())?;
         }
         let model = navitia_model::Model::new(collections)?;
         let model = transfers::generates_transfers(

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -224,11 +224,10 @@ impl<T> Collection<T> {
     /// # }
     /// # fn main() { run().unwrap() }
     /// ```
-    pub fn merge(&mut self, other: Self) -> Result<()> {
+    pub fn merge(&mut self, other: Self) {
         for item in other {
             self.push(item);
         }
-        Ok(())
     }
 
     /// Takes the corresponding vector without clones or allocation,
@@ -479,18 +478,44 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// let mut c1 = CollectionWithId::new(vec![Obj("foo"), Obj("bar")])?;
     /// let mut c2 = CollectionWithId::new(vec![Obj("foo"), Obj("qux")])?;
     /// let mut c3 = CollectionWithId::new(vec![Obj("corge"), Obj("grault")])?;
-    /// assert!(c1.merge(c2).is_err());
-    /// c1.merge(c3);
+    /// assert!(c1.try_merge(c2).is_err());
+    /// c1.try_merge(c3);
     /// assert_eq!(c1.len(), 4);
     /// # Ok(())
     /// # }
     /// # fn main() { run().unwrap() }
     /// ```
-    pub fn merge(&mut self, other: Self) -> Result<()> {
+    pub fn try_merge(&mut self, other: Self) -> Result<()> {
         for item in other {
             self.push(item)?;
         }
         Ok(())
+    }
+
+    /// Merge a `CollectionWithId` parameter into the current one. If any identifier into the
+    /// `CollectionWithId` parameter is already in the collection, `CollectionWithId` is not added.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use navitia_model::collection::*;
+    /// # fn run() -> navitia_model::Result<()> {
+    /// # #[derive(PartialEq, Debug)] struct Obj(&'static str);
+    /// # impl Id<Obj> for Obj { fn id(&self) -> &str { self.0 } }
+    /// let mut c1 = CollectionWithId::new(vec![Obj("foo"), Obj("bar")])?;
+    /// let mut c2 = CollectionWithId::new(vec![Obj("foo"), Obj("qux")])?;
+    /// c1.merge(c2);
+    /// assert_eq!(c1.len(), 3);
+    /// # Ok(())
+    /// # }
+    /// # fn main() { run().unwrap() }
+    /// ```
+    pub fn merge(&mut self, other: Self) {
+        for item in other {
+            match self.push(item) {
+                _ => continue,
+            }
+        }
     }
 
     // Return true if the collection has no objects.

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1714,8 +1714,8 @@ mod tests {
             );
             assert_eq!(
                 vec![
-                    ("my_prefix:route_1", "my_prefix:agency_1", "my_prefix:Bus"),
-                    ("my_prefix:route_2", "my_prefix:agency_1", "my_prefix:Bus"),
+                    ("my_prefix:route_1", "my_prefix:agency_1", "Bus"),
+                    ("my_prefix:route_2", "my_prefix:agency_1", "Bus"),
                 ],
                 extract(
                     |obj| (
@@ -1744,10 +1744,7 @@ mod tests {
                 vec!["my_prefix:stop:sa:03", "my_prefix:stop:sp:01"],
                 extract_ids(&collections.comments)
             );
-            assert_eq!(
-                vec!["my_prefix:Bus"],
-                extract_ids(&collections.commercial_modes)
-            );
+            assert_eq!(vec!["Bus"], extract_ids(&collections.commercial_modes));
             assert_eq!(
                 vec![
                     ("my_prefix:sp:01", "my_prefix:sp:01"),

--- a/src/model.rs
+++ b/src/model.rs
@@ -63,7 +63,7 @@ pub struct Collections {
 impl Collections {
     /// Merge the `Collections` parameter into the current `Collections` by consecutively merging
     /// each collections representing the model.  Fails in case of id collision.
-    pub fn merge(&mut self, c: Collections) -> Result<()> {
+    pub fn try_merge(&mut self, c: Collections) -> Result<()> {
         let Collections {
             contributors,
             datasets,
@@ -88,14 +88,14 @@ impl Collections {
             stop_time_ids,
             stop_time_comments,
         } = c;
-        self.contributors.merge(contributors)?;
-        self.datasets.merge(datasets)?;
-        self.networks.merge(networks)?;
-        self.commercial_modes.merge(commercial_modes)?;
-        self.lines.merge(lines)?;
-        self.routes.merge(routes)?;
+        self.contributors.try_merge(contributors)?;
+        self.datasets.try_merge(datasets)?;
+        self.networks.try_merge(networks)?;
+        self.commercial_modes.merge(commercial_modes);
+        self.lines.try_merge(lines)?;
+        self.routes.try_merge(routes)?;
         self.physical_modes.extend(physical_modes);
-        self.stop_areas.merge(stop_areas)?;
+        self.stop_areas.try_merge(stop_areas)?;
 
         fn get_new_idx<T>(
             old_idx: Idx<T>,
@@ -117,7 +117,7 @@ impl Collections {
         let vj_idx_to_id = idx_to_id(&vehicle_journeys);
         let c_idx_to_id = idx_to_id(&comments);
 
-        self.stop_points.merge(stop_points)?;
+        self.stop_points.try_merge(stop_points)?;
 
         // Update stop point idx in new stop times
         let mut vjs = vehicle_journeys.take();
@@ -131,7 +131,7 @@ impl Collections {
             }
         }
         vehicle_journeys = CollectionWithId::new(vjs)?;
-        self.vehicle_journeys.merge(vehicle_journeys)?;
+        self.vehicle_journeys.try_merge(vehicle_journeys)?;
 
         fn update_vj_idx<'a, T: Clone>(
             map: &'a HashMap<(Idx<VehicleJourney>, u32), T>,
@@ -158,7 +158,7 @@ impl Collections {
             &vj_idx_to_id,
         ));
 
-        self.comments.merge(comments)?;
+        self.comments.try_merge(comments)?;
         let mut new_stop_time_comments = HashMap::new();
         for ((old_vj_idx, sequence), value) in &stop_time_comments {
             let new_vj_idx =
@@ -168,13 +168,13 @@ impl Collections {
         }
         self.stop_time_comments.extend(new_stop_time_comments);
         self.feed_infos.extend(feed_infos);
-        self.calendars.merge(calendars)?;
-        self.companies.merge(companies)?;
-        self.equipments.merge(equipments)?;
-        self.transfers.merge(transfers)?;
-        self.trip_properties.merge(trip_properties)?;
-        self.geometries.merge(geometries)?;
-        self.admin_stations.merge(admin_stations)?;
+        self.calendars.try_merge(calendars)?;
+        self.companies.try_merge(companies)?;
+        self.equipments.try_merge(equipments)?;
+        self.transfers.merge(transfers);
+        self.trip_properties.try_merge(trip_properties)?;
+        self.geometries.try_merge(geometries)?;
+        self.admin_stations.merge(admin_stations);
         Ok(())
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -311,11 +311,6 @@ impl Id<CommercialMode> for CommercialMode {
         &self.id
     }
 }
-impl AddPrefix for CommercialMode {
-    fn add_prefix(&mut self, prefix: &str) {
-        self.id = prefix.to_string() + &self.id;
-    }
-}
 
 impl_with_id!(CommercialMode);
 
@@ -562,9 +557,9 @@ impl AddPrefix for Line {
     fn add_prefix(&mut self, prefix: &str) {
         self.id = prefix.to_string() + &self.id;
         self.network_id = prefix.to_string() + &self.network_id;
-        self.commercial_mode_id = prefix.to_string() + &self.commercial_mode_id;
     }
 }
+
 impl_codes!(Line);
 impl_properties!(Line);
 impl_comment_links!(Line);

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -63,7 +63,6 @@ pub fn read_config<P: AsRef<path::Path>>(
 pub fn add_prefix(prefix: String, collections: &mut Collections) -> Result<()> {
     let prefix = prefix + ":";
     info!("Adding prefix: \"{}\"", &prefix);
-    add_prefix_to_collection_with_id(&mut collections.commercial_modes, &prefix)?;
     add_prefix_to_collection_with_id(&mut collections.networks, &prefix)?;
     add_prefix_to_collection_with_id(&mut collections.companies, &prefix)?;
     add_prefix_to_collection_with_id(&mut collections.stop_points, &prefix)?;

--- a/tests/merge_ntfs.rs
+++ b/tests/merge_ntfs.rs
@@ -34,7 +34,7 @@ fn merge_collections_with_collisions() {
     for input_directory in input_collisions.iter() {
         let to_append_model = navitia_model::ntfs::read(input_directory).unwrap();
         collections
-            .merge(to_append_model.into_collections())
+            .try_merge(to_append_model.into_collections())
             .unwrap();
     }
 }
@@ -47,12 +47,19 @@ fn merge_collections_ok() {
         let to_append_model = navitia_model::ntfs::read(input_directory).unwrap();
 
         collections
-            .merge(to_append_model.into_collections())
+            .try_merge(to_append_model.into_collections())
             .unwrap();
     }
     assert_eq!(collections.contributors.len(), 2);
     assert_eq!(collections.datasets.len(), 2);
     assert_eq!(collections.networks.len(), 3);
+    // check that commercial mode Bus appears once.
+    let cm_bus: Vec<_> = collections
+        .commercial_modes
+        .values()
+        .filter(|cm| cm.id == "Bus" && cm.name == "Bus")
+        .collect();
+    assert_eq!(cm_bus.len(), 1);
     assert_eq!(collections.commercial_modes.len(), 6);
     assert_eq!(collections.lines.len(), 6);
     assert_eq!(collections.routes.len(), 8);
@@ -198,7 +205,7 @@ fn merge_collections_with_transfers_ok() {
             let to_append_model = navitia_model::ntfs::read(input_directory).unwrap();
 
             collections
-                .merge(to_append_model.into_collections())
+                .try_merge(to_append_model.into_collections())
                 .unwrap();
         }
         let model = Model::new(collections).unwrap();


### PR DESCRIPTION
Problem: when we convert 2 GTFS to NTFS and merge them,  we can have 2 same commercial mode, for example "Bus" with 2 different ids.

We decided with @prhod and @papailio to normalize commercial modes and not add prefix on it