### PR TITLE
Doc Fares: added specs for writing NTFS fares

### DIFF
--- a/src/documentation/write_ntfs_fares.md
+++ b/src/documentation/write_ntfs_fares.md
@@ -3,22 +3,24 @@
 This document describes how fares specified in Navitia Transit Model are transformed into a [NTFS fare feed](https://github.com/CanalTP/navitia/blob/dev/documentation/ntfs/ntfs_fare_extension_fr.md).
 
 In this initial version: 
-- only the files [prices.csv](#pricescsv) and [od_fares.csv](#od_farescsv) are written, as the NTM fares model does not yet support special conditions for the tickets
-- only tickets on origin-destination stops are taken into account.
+- only tickets on origin-destination stops are taken into account
+- if a ticket is specified for a specific line or network, this information is ignored
+- the validity duration and the transfers allowed for a ticket, if specified, are ignored
 - tickets specified in a currency different than EUR are ignored.
 
 These limitations will be adressed in a later version.
 
 ### prices.csv
 As a reminder, this file has no header and the order of the NTFS fields must be respected.
+
 NTFS field | NTM object | NTM property | Notes/Mapping rule
 --- | --- | --- | ---
-\*clef de ticket\* | Ticket | ticket_id
+\*clef de ticket\* | Ticket | ticket_id |
 \*date de début de validité\* | Ticket | start_date | Starting date of the validity period of the fare structure in the form YYYYMMDD.
 \*date de fin de validité\* | Ticket | end_date | The date after the specified end date in the form YYYYMMDD.
 \*prix\* | Ticket | price | The specified value is converted into euro cents.
 \*name\* | | | Fixed value `Ticket Orgine-Destination`.
-\*champ ignoré\* |  |  | This field is explicitly left empty.
+\*champ ignoré\* | | | This field is explicitly left empty.
 \*commentaire\* | | | This field is explicitly left empty.
 \*devise\* | Ticket | currency_type | The value is set to `centime` provided that the currency used for the ticket is EUR.
 
@@ -27,10 +29,12 @@ NTFS field | NTM object | NTM property | Notes/Mapping rule
 NTFS field | NTM object | NTM property | Notes/Mapping rule
 --- | --- | --- | ---
 Origin ID | OD Rules | origin_stoparea_id | 
-Origin name | | This field is explicitly left empty.
-Origin mode | | Fixed value `stop`.
+Origin name | | | This field is explicitly left empty.
+Origin mode | | | Fixed value `stop`.
 Destination ID | OD Rules | dest_stoparea_id | 
-Destination name | | This field is explicitly left empty.
-Destination mode | | Fixed value `stop`.
+Destination name | | | This field is explicitly left empty.
+Destination mode | | | Fixed value `stop`.
 ticket_id | OD Rules | ticket_id | Link to the ticket specified in [prices](#pricescsv)
 
+### fares.csv
+As the NTM fares model does not yet support special conditions for tickets, no content is written in this file (empty file with a header row).

--- a/src/documentation/write_ntfs_fares.md
+++ b/src/documentation/write_ntfs_fares.md
@@ -10,6 +10,8 @@ In this initial version:
 
 These limitations will be adressed in a later version.
 
+In the following, the NTFS fields that are not specified are ignored and not detailed.
+
 ### prices.csv
 As a reminder, this file has no header and the order of the NTFS fields must be respected.
 
@@ -29,10 +31,8 @@ NTFS field | NTM object | NTM property | Notes/Mapping rule
 NTFS field | NTM object | NTM property | Notes/Mapping rule
 --- | --- | --- | ---
 Origin ID | OD Rules | origin_stoparea_id | 
-Origin name | | | This field is explicitly left empty.
 Origin mode | | | Fixed value `stop`.
 Destination ID | OD Rules | dest_stoparea_id | 
-Destination name | | | This field is explicitly left empty.
 Destination mode | | | Fixed value `stop`.
 ticket_id | OD Rules | ticket_id | Link to the ticket specified in [prices](#pricescsv)
 

--- a/src/documentation/write_ntfs_fares.md
+++ b/src/documentation/write_ntfs_fares.md
@@ -4,7 +4,7 @@ This document describes how fares specified in Navitia Transit Model are transfo
 
 In this initial version: 
 - only tickets on origin-destination stops are taken into account
-- if a ticket is specified for a specific line or network, this information is ignored
+- only constraints on physical modes are taken into account (if a ticket is specified for a specific line or network, this information is ignored)
 - the validity duration and the transfers allowed for a ticket, if specified, are ignored
 - tickets specified in a currency different than EUR are ignored.
 
@@ -37,4 +37,13 @@ Destination mode | | | Fixed value `stop`.
 ticket_id | OD Rules | ticket_id | Link to the ticket specified in [prices](#pricescsv)
 
 ### fares.csv
-As the NTM fares model does not yet support special conditions for tickets, no content is written in this file (empty file with a header row).
+For each distinct physical mode specified in `OD Rules`, a row is created in this file in order to allow to represent transitions for the origin-destination tickets.
+
+NTFS field | NTM object | NTM property | Notes/Mapping rule
+--- | --- | --- | ---
+avant changement | | | Fixed value `*`.
+après changement | OD Rules | physical_mode_id | The id is prefixed with `mode=physical_mode:`.
+début trajet | | | This field is explicitly left empty.
+fin trajet | | | This field is explicitly left empty.
+condition globale | | | Fixed value `with_changes`.
+clef ticket | | | This field is explicitly left empty.

--- a/src/documentation/write_ntfs_fares.md
+++ b/src/documentation/write_ntfs_fares.md
@@ -1,0 +1,36 @@
+# Writing NTFS fares
+## Introduction
+This document describes how fares specified in Navitia Transit Model are transformed into a [NTFS fare feed](https://github.com/CanalTP/navitia/blob/dev/documentation/ntfs/ntfs_fare_extension_fr.md).
+
+In this initial version: 
+- only the files [prices.csv](#pricescsv) and [od_fares.csv](#od_farescsv) are written, as the NTM fares model does not yet support special conditions for the tickets
+- only tickets on origin-destination stops are taken into account.
+- tickets specified in a currency different than EUR are ignored.
+
+These limitations will be adressed in a later version.
+
+### prices.csv
+As a reminder, this file has no header and the order of the NTFS fields must be respected.
+NTFS field | NTM object | NTM property | Notes/Mapping rule
+--- | --- | --- | ---
+\*clef de ticket\* | Ticket | ticket_id
+\*date de début de validité\* | Ticket | start_date | Starting date of the validity period of the fare structure in the form YYYYMMDD.
+\*date de fin de validité\* | Ticket | end_date | The date after the specified end date in the form YYYYMMDD.
+\*prix\* | Ticket | price | The specified value is converted into euro cents.
+\*name\* | | | Fixed value `Ticket Orgine-Destination`.
+\*champ ignoré\* |  |  | This field is explicitly left empty.
+\*commentaire\* | | | This field is explicitly left empty.
+\*devise\* | Ticket | currency_type | The value is set to `centime` provided that the currency used for the ticket is EUR.
+
+### od_fares.csv
+
+NTFS field | NTM object | NTM property | Notes/Mapping rule
+--- | --- | --- | ---
+Origin ID | OD Rules | origin_stoparea_id | 
+Origin name | | This field is explicitly left empty.
+Origin mode | | Fixed value `stop`.
+Destination ID | OD Rules | dest_stoparea_id | 
+Destination name | | This field is explicitly left empty.
+Destination mode | | Fixed value `stop`.
+ticket_id | OD Rules | ticket_id | Link to the ticket specified in [prices](#pricescsv)
+

--- a/src/documentation/write_ntfs_fares.md
+++ b/src/documentation/write_ntfs_fares.md
@@ -30,9 +30,9 @@ NTFS field | NTM object | NTM property | Notes/Mapping rule
 
 NTFS field | NTM object | NTM property | Notes/Mapping rule
 --- | --- | --- | ---
-Origin ID | OD Rules | origin_stoparea_id | 
+Origin ID | OD Rules | origin_stoparea_id | The id is prefixed with `stop_area:`.
 Origin mode | | | Fixed value `stop`.
-Destination ID | OD Rules | dest_stoparea_id | 
+Destination ID | OD Rules | dest_stoparea_id | The id is prefixed with `stop_area:`.
 Destination mode | | | Fixed value `stop`.
 ticket_id | OD Rules | ticket_id | Link to the ticket specified in [prices](#pricescsv)
 


### PR DESCRIPTION
First version of specs for writing NTFS fares (provided that at this stage, the NTFS fares model is far richer than the internal fares model).