### PR TITLE
Doc Fares: added specs for reading NTFS fares

### DIFF
--- a/src/documentation/read_ntfs_fares.md
+++ b/src/documentation/read_ntfs_fares.md
@@ -1,0 +1,32 @@
+# Reading NTFS fares
+## Introduction
+This document describes how [NTFS fares](https://github.com/CanalTP/navitia/blob/dev/documentation/ntfs/ntfs_fare_extension_fr.md) are loaded in Navitia Transit Model.
+
+In this initial version: 
+- only tickets on origin-destination stops are taken into account
+- the NTFS file *fares.csv* is ignored, as the NTM fares model does not yet support special conditions on tickets (e.g validity duration, number of transfers allowed, constraints on networks/lines) 
+- tickets specified in a currency different than EUR are ignored
+- only tickets on origin-destination stops are taken into account
+
+### Loading Tickets
+
+NTM property | NTFS file | NTFS field | Note/mapping rule
+--- | --- | --- | ---
+id | prices.csv | \*clef de ticket\* | 
+start_date | prices.csv | \*date de début de validité\* | 
+end_date | prices.csv | \*date de fin de validité\* | The previous date of the specified date in the input.
+currency_type | prices.csv | \*devise\* | The currency is set to `EUR` when the input value is `centime`.
+price | prices.csv | \*prix\* | The specified input value is converted into EUR.
+validity_duration | | | This field is ignored.
+transfers | | | This field is ignored.
+
+### Loading OD Rules
+
+NTM property | NTFS file | NTFS field | Note/mapping rule
+--- | --- | --- | ---
+id | prices.csv | \*clef de ticket\* | The id is prefixes with `OD:`.
+ticket_id | | | Id of the `Ticket` to which this `OD Rule` is applied.
+origin_stoparea_id | od_fares.csv | Origin ID | Id of the origin stop_area in Navitia when the value of Origin mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+dest_stoparea_id | od_fares.csv | Origin ID | Id of the destination stop_area in Navitia when the value of Destination mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+line_id | | | This field is ignored.
+network_id | | | This field is ignored.

--- a/src/documentation/read_ntfs_fares.md
+++ b/src/documentation/read_ntfs_fares.md
@@ -6,7 +6,9 @@ In this initial version:
 - only tickets on origin-destination stops are taken into account
 - the NTFS file *fares.csv* is ignored, as the NTM fares model does not yet support special conditions on tickets (e.g validity duration, number of transfers allowed, constraints on networks/lines) 
 - tickets specified in a currency different than EUR are ignored
-- only tickets on origin-destination stops are taken into account
+- only tickets on origin-destination stops are taken into account.
+
+These limitations will be covered in later version, following the updates of the NTM fares model.
 
 ### Loading Tickets
 
@@ -15,7 +17,7 @@ NTM property | NTFS file | NTFS field | Note/mapping rule
 id | prices.csv | \*clef de ticket\* | 
 start_date | prices.csv | \*date de début de validité\* | 
 end_date | prices.csv | \*date de fin de validité\* | The previous date of the specified date in the input.
-currency_type | prices.csv | \*devise\* | The currency is set to `EUR` when the input value is `centime`.
+currency_type | prices.csv | \*devise\* | The currency is set to `EUR` when the input value is `centime`. Otherwise, the ticket is ignored.
 price | prices.csv | \*prix\* | The specified input value is converted into EUR.
 validity_duration | | | This field is ignored.
 transfers | | | This field is ignored.
@@ -24,9 +26,9 @@ transfers | | | This field is ignored.
 
 NTM property | NTFS file | NTFS field | Note/mapping rule
 --- | --- | --- | ---
-id | prices.csv | \*clef de ticket\* | The id is prefixes with `OD:`.
+id | prices.csv | \*clef de ticket\* | Id of the `OD Rule`. The id is prefixed with `OD:`.
 ticket_id | | | Id of the `Ticket` to which this `OD Rule` is applied.
 origin_stoparea_id | od_fares.csv | Origin ID | Id of the origin stop_area in Navitia when the value of Origin mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
-dest_stoparea_id | od_fares.csv | Origin ID | Id of the destination stop_area in Navitia when the value of Destination mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+dest_stoparea_id | od_fares.csv | Destination ID | Id of the destination stop_area in Navitia when the value of Destination mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
 line_id | | | This field is ignored.
 network_id | | | This field is ignored.

--- a/src/documentation/read_ntfs_fares.md
+++ b/src/documentation/read_ntfs_fares.md
@@ -10,6 +10,8 @@ In this initial version:
 
 These limitations will be covered in later version, following the updates of the NTM fares model.
 
+In the following, the NTM properties that are not specified are ignored and not detailed.
+
 ### Loading Tickets
 
 NTM property | NTFS file | NTFS field | Note/mapping rule
@@ -19,8 +21,6 @@ start_date | prices.csv | \*date de début de validité\* |
 end_date | prices.csv | \*date de fin de validité\* | The previous date of the specified date in the input.
 currency_type | prices.csv | \*devise\* | The currency is set to `EUR` when the input value is `centime`. Otherwise, the ticket is ignored.
 price | prices.csv | \*prix\* | The specified input value is converted into EUR.
-validity_duration | | | This field is ignored.
-transfers | | | This field is ignored.
 
 ### Loading OD Rules
 
@@ -30,5 +30,3 @@ id | prices.csv | \*clef de ticket\* | Id of the `OD Rule`. The id is prefixed w
 ticket_id | | | Id of the `Ticket` to which this `OD Rule` is applied.
 origin_stoparea_id | od_fares.csv | Origin ID | Id of the origin stop_area in Navitia when the value of Origin mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
 dest_stoparea_id | od_fares.csv | Destination ID | Id of the destination stop_area in Navitia when the value of Destination mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
-line_id | | | This field is ignored.
-network_id | | | This field is ignored.

--- a/src/documentation/read_ntfs_fares.md
+++ b/src/documentation/read_ntfs_fares.md
@@ -4,7 +4,7 @@ This document describes how [NTFS fares](https://github.com/CanalTP/navitia/blob
 
 In this initial version: 
 - only tickets on origin-destination stops are taken into account
-- the NTFS file *fares.csv* is ignored, as the NTM fares model does not yet support special conditions on tickets (e.g validity duration, number of transfers allowed, constraints on networks/lines) 
+- only transitions based on physical modes are taken into account, all other constraints are ignored (e.g validity duration, number of transfers allowed, constraints on networks/lines) 
 - tickets specified in a currency different than EUR are ignored
 - only tickets on origin-destination stops are taken into account.
 
@@ -28,5 +28,6 @@ NTM property | NTFS file | NTFS field | Note/mapping rule
 --- | --- | --- | ---
 id | prices.csv | \*clef de ticket\* | Id of the `OD Rule`. The id is prefixed with `OD:`.
 ticket_id | | | Id of the `Ticket` to which this `OD Rule` is applied.
-origin_stoparea_id | od_fares.csv | Origin ID | Id of the origin stop_area in Navitia when the value of Origin mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
-dest_stoparea_id | od_fares.csv | Destination ID | Id of the destination stop_area in Navitia when the value of Destination mode is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+origin_stoparea_id | od_fares.csv | Origin ID | Id of the origin stop_area in Navitia when the value of "Origin mode" is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+dest_stoparea_id | od_fares.csv | Destination ID | Id of the destination stop_area in Navitia when the value of "Destination mode" is set to `stop`. Otherwise, the rule and the corresponding ticket is ignored.
+physical_mode_id | fares.csv | après changement | Id of the physical mode in Navitia associated to this `OD Rule` when the value of "condition globale" is set to `with_changes`. 


### PR DESCRIPTION
First version of reading NTFS fares, coupled with the current version of writing (and the version of the internal model).